### PR TITLE
Connect to specific networks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ venv.bak/
 
 # Misc
 .history
+/test

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is useful if you have, for example, one traefik proxy which handle incoming
 
 ## Features
 
-- 🌐 **Automatic Network Connection**: Automatically connects Traefik to the networks of newly created containers that are labeled for Traefik.
+- 🌐 **Automatic Network Connection**: Automatically connects Traefik to the networks of newly created containers that are labeled for Traefik. Ability to indicate which networks to connect to.
 - 🔌 **Intelligent Network Disconnection**: Disconnects Traefik from networks of containers that are no longer running, ensuring a clean and efficient network setup.
 - ⚙️ **Dynamic Configuration**: Utilizes a YAML configuration file, CLI arguments and/or environment variables for easy setup and adjustments without needing to alter the source code.
 - 🔒 **TLS Support**: Secure your Docker API communication by specifying TLS configuration details.
@@ -63,7 +63,7 @@ For more details about the configuration options, refer to the [Configuration](#
 Modify `config.yaml` to adjust the Traefik container name, the label to monitor, and other settings. Key configuration options include:
 
 - `traefik.containerName`: Name of the Traefik container in Docker.
-- `monitoredLabel`: Docker label that triggers network connection actions.
+- `traefik.monitoredLabel`: Docker label that triggers network connection actions.
 - `logLevel`: Adjust the verbosity of the script's output.
 
 For a detailed explanation of all configuration options, refer to the comments within `config.yaml`.
@@ -129,7 +129,7 @@ To manage the Traefik Automatic Docker Network Connector as a service using syst
 ## How It Works
 
 - **Monitoring Docker Events**: Listens for creation and destruction events of containers and manages network connections accordingly.
-- **Connecting Traefik**: When a container with the specified label is created, it connects Traefik to its network if not already connected.
+- **Connecting Traefik**: When a container with the specified label is created, it connects Traefik to its network if not already connected. If a config specified label is present (default is `autoproxy.networks`) only these networks will be connected to.
 - **Disconnecting Traefik**: If a container is destroyed, it checks if Traefik should be disconnected from its network, based on other containers' usage of the network.
 
 ## TLS Configuration
@@ -166,6 +166,12 @@ This section addresses common issues and questions:
 
 - **Q: How can I debug issues with incorrect configuration values?**
   - **A:** Ensure that your command line arguments and environment variables are correctly formatted and match the expected patterns. Use the `--help` option with the script to see available command line arguments.
+
+
+- **Q: How can I specify the networks Traefik should connect to?**
+  - **A:** To specify the networks Traefik should connect to, you can set the `autoproxy.networks` label on the Docker containers you want Traefik to manage. Add the label with the network names separated by commas. You can change the label in [Configuration](#configuration).
+
+
 
 ## Contributing
 

--- a/config.yaml
+++ b/config.yaml
@@ -27,6 +27,9 @@ logLevel:
 # Traefik Specific Configuration
 traefik:
   # Name of the Traefik container
-  containerName: "traefik-reverse-proxy-1"
+  containerName: "traefik"
   # Label to monitor for Traefik management (using regex)
   monitoredLabel: "^traefik.enable$"
+  # Label of auto_docker_proxy network to connect to (not mandatory on services but if present, only connect to these networks)
+  # For example, if you have 2 docker networks, "autoproxy.networks" label can be "autoproxy.networks=network1" to only connect to network1
+  networkLabel: "autoproxy.networks"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,18 @@
-version: '3'
-
 services:
+  traefik:
+    image: traefik:v2.11
+    container_name: traefik
+    command:
+      - "--log.level=INFO"
+      - "--api.dashboard=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+    ports:
+      - "8000:80"
+
   auto_docker_proxy:
     image: obeoneorg/auto_docker_proxy
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+

--- a/main.py
+++ b/main.py
@@ -102,7 +102,7 @@ def connect_traefik_to_network(container):
         network = client.networks.get(net)
         
         if container.labels.get('com.docker.compose.project') and 'com.docker.compose.project' in network.attrs['Labels']:
-            if container.labels.get('com.docker.compose.project') == network.attrs['Labels']['com.docker.compose.project'] and network.attrs['Labels']['com.docker.compose.net']  in allowed_networks:
+            if container.labels.get('com.docker.compose.project') == network.attrs['Labels']['com.docker.compose.project'] and network.attrs['Labels']['com.docker.compose.network']  in allowed_networks:
                 app_logger.debug(f"Network {network.attrs['Name']} corresponds to a docker compose network described in the allowed networks.")
             
                 # Construct the real network name for Docker Compose projects

--- a/main.py
+++ b/main.py
@@ -58,57 +58,72 @@ def update_container_cache(container_or_id):
 
 def connect_to_all_relevant_networks():
     """
-    Connects Traefik to all networks of containers with the 'traefik.enable=true' label.
+    Connects Traefik to all networks of containers with the 'traefik.enable=true' label and ensures connection only to networks specified in the 'traefik.networkLabel' label if present.
 
-    This function iterates over all containers labeled 'traefik.enable=true' and connects the Traefik container to
-    their networks if it's not already connected. This ensures Traefik can route traffic to these containers.
+    This function iterates over all containers labeled 'traefik.enable=true'. If the container has a 'traefik.networkLabel' label, it checks if the network is listed in the label's value before connecting the Traefik container to their networks if it's not already connected. This ensures Traefik can route traffic to these containers.
     """
-    app_logger.debug("Searching for Traefik container to connect to relevant networks.")
-    
-    try:
-        traefik_container = client.containers.get(config.traefik.containerName)
-        
-    except docker.errors.NotFound:
-        app_logger.warning("Traefik container not found. Skipping network connection.")
+    if not is_traefik_running():
+        app_logger.warning("Traefik is not running. Skipping network connection.")
         return
     
-    traefik_nets = set(traefik_container.attrs["NetworkSettings"]["Networks"])
-
+    app_logger.debug("Searching for Traefik container to connect to relevant networks.")
+    
     for container in client.containers.list(filters={"label": "traefik.enable=true"}):
         update_container_cache(container)
-
-        for net in container.attrs["NetworkSettings"]["Networks"]:
-            if net not in traefik_nets:
-                app_logger.debug(f"Connecting Traefik to network {net}.")
-                network = client.networks.get(net)
-                network.connect(traefik_container)
-                traefik_nets.add(net)
-                app_logger.info(f"Traefik connected to network {net}.")
-            else:
-                app_logger.info(f"Traefik already connected to network {net}, skipping.")
+        connect_traefik_to_network(container)
+    
+    app_logger.debug("Finished searching for Traefik container to connect to relevant networks.")
 
 def connect_traefik_to_network(container):
     """
-    Connects Traefik to the network of a specified container if not already connected.
+    Connects Traefik to the network of a specified container if not already connected, considering the 'traefik.networkLabel' for allowed networks, and accounting for external networks.
 
     Args:
         container (docker.models.containers.Container): Container to connect Traefik to its network.
 
     This function checks if Traefik is already connected to the network of the specified container. If not, it
-    connects Traefik to this network to enable traffic routing.
+    connects Traefik to this network to enable traffic routing. It also checks if the 'traefik.networkLabel' is present
+    on the container and if so, only connects to the networks listed in this label. Additionally, it accounts for
+    external networks in network names.
     """
-    app_logger.debug(f"Connecting Traefik to network of container {container.name}.")
+    app_logger.debug(f"Attempting to connect Traefik to the network of container {container.name}.")
+    # Retrieve the Traefik container based on configuration
     traefik_container = client.containers.get(config.traefik.containerName)
-    target_networks = set(container.attrs["NetworkSettings"]["Networks"])
+    # Determine the target networks of the specified container
+    target_networks = set(container.attrs["NetworkSettings"]["Networks"].keys())
+    # Retrieve allowed networks from the container's labels, if specified
+    allowed_networks_label = container.labels.get(config.traefik.networkLabel, "")
+    allowed_networks = allowed_networks_label.split(",")
+    
+    app_logger.debug(f"Allowed networks: {allowed_networks}")
 
     for net in target_networks:
-        if net not in traefik_container.attrs["NetworkSettings"]["Networks"]:
-            app_logger.debug(f"Connecting Traefik to network {net}.")
-            network = client.networks.get(net)
-            network.connect(traefik_container)
-            app_logger.info(f"Traefik connected to network {net}.")
+        # Attempt to retrieve the network object; checks for external networks by matching labels
+        network = client.networks.get(net)
+        
+        if container.labels.get('com.docker.compose.project') and 'com.docker.compose.project' in network.attrs['Labels']:
+            if container.labels.get('com.docker.compose.project') == network.attrs['Labels']['com.docker.compose.project'] and network.attrs['Labels']['com.docker.compose.net']  in allowed_networks:
+                app_logger.debug(f"Network {network.attrs['Name']} corresponds to a docker compose network described in the allowed networks.")
+            
+                # Construct the real network name for Docker Compose projects
+                real_network = f"{network.attrs['Labels']['com.docker.compose.project']}_{network.attrs['Labels']['com.docker.compose.network']}"
+                # Determine if the network is listed in the allowed networks, adjusting the list as necessary
+                index_allowed = allowed_networks.index(network.attrs['Labels']['com.docker.compose.network']) if network.attrs['Labels']['com.docker.compose.network'] in allowed_networks else -1
+                
+                if index_allowed >= 0:
+                    allowed_networks[index_allowed] = real_network
+                    app_logger.debug(f"Adjusted allowed network to {real_network}.")
+        
+        # Connect Traefik to the network if allowed, or log that it's skipping the connection
+        if allowed_networks == [''] or net in allowed_networks:
+            if net not in traefik_container.attrs["NetworkSettings"]["Networks"]:
+                app_logger.debug(f"Connecting Traefik to network {net}.")
+                network.connect(traefik_container)
+                app_logger.info(f"Successfully connected Traefik to network {net}.")
+            else:
+                app_logger.info(f"Traefik is already connected to network {net}, skipping connection.")
         else:
-            app_logger.info(f"Traefik already connected to network {net}, skipping.")
+            app_logger.info(f"Network {net} is not listed in allowed networks, skipping connection.")
 
 def disconnect_traefik_from_network(container):
     """
@@ -153,6 +168,16 @@ def disconnect_traefik_from_network(container):
         else:
             app_logger.info(f"Traefik not connected to network {net}, skipping disconnection.")
 
+def is_traefik_running():
+    """
+    Checks if Traefik container is running.
+
+    Returns:
+        bool: True if Traefik container is running, False otherwise.
+    """
+    traefik_running = any(container.status == "running" for container in client.containers.list() if container.name == config.traefik.containerName)
+    return traefik_running
+
 def monitor_events():
     """
     Monitors Docker events for container creation and destruction and manages Traefik's network connections accordingly.
@@ -171,6 +196,10 @@ def monitor_events():
         # Filter out events that are not related to container creation/destruction
         if event.get('Type') != 'container':
             continue
+        
+        if not is_traefik_running():
+            app_logger.warning("Traefik is not running. Skipping event handling.")
+            continue
 
         # Update the container cache on every container event (can be manual connection to network for example)
         update_container_cache(event["id"])
@@ -185,10 +214,6 @@ def monitor_events():
             # Skip further processing if the container is not found or Traefik is not running
             if container is None:
                 app_logger.warning(f"Container {event['id']} not found. Skipping event handling.")
-                continue
-            traefik_running = any(container.status == "running" for container in client.containers.list() if container.name == config.traefik.containerName)
-            if not traefik_running:
-                app_logger.info("Traefik container is not running. Skipping event handling.")
                 continue
 
             # Define the monitored label pattern


### PR DESCRIPTION
Add the ability to indicate which network to connect.

So if you have a container connected to a public and a db networks, you can limit traefik to connect to public 