### PR TITLE
Renaming project

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -45,6 +45,8 @@ jobs:
           tags: |
             ghcr.io/obeone/auto_docker_proxy:latest
             docker.io/obeoneorg/auto_docker_proxy:latest
+            ghcr.io/obeone/traefik_network_connector:latest
+            docker.io/obeoneorg/traefik_network_connector:latest
           platforms: |
             linux/amd64
             linux/arm64
@@ -59,6 +61,8 @@ jobs:
         run: |
           cosign sign --yes ghcr.io/obeone/auto_docker_proxy@${DIGEST}
           cosign sign --yes docker.io/obeoneorg/auto_docker_proxy@${DIGEST}
+          cosign sign --yes ghcr.io/obeone/traefik_network_connector@${DIGEST}
+          cosign sign --yes docker.io/obeoneorg/traefik_network_connector@${DIGEST}
         env:
           COSIGN_EXPERIMENTAL: true
           DIGEST: ${{ steps.build-and-push.outputs.digest }}

--- a/README.md
+++ b/README.md
@@ -6,22 +6,24 @@ This is useful if you have, for example, one traefik proxy which handle incoming
 
 ## Table of Contents
 
-- [Features](#features)
-- [Requirements](#requirements)
-- [Usage](#usage)
-- [Configuration](#configuration)
-  - [Configuration File](#configuration-file)
-  - [Command Line Arguments](#command-line-arguments)
-  - [Environment Variables](#environment-variables)
-- [Usage as a system daemon](#usage-as-a-system-daemon)
-  - [Installation](#installation)
-  - [Running](#running)
-  - [Systemd Service Setup](#systemd-service-setup)
-- [How It Works](#how-it-works)
-- [TLS Configuration](#tls-configuration)
-- [FAQs / Troubleshooting](#faqs--troubleshooting)
-- [Contributing](#contributing)
-- [Author](#author)
+- [Traefik Automatic Docker Network Connector](#traefik-automatic-docker-network-connector)
+  - [Table of Contents](#table-of-contents)
+  - [Features](#features)
+  - [Requirements](#requirements)
+  - [Usage](#usage)
+  - [Configuration](#configuration)
+    - [Configuration File](#configuration-file)
+    - [Command Line Arguments](#command-line-arguments)
+    - [Environment Variables](#environment-variables)
+  - [Usage as a system daemon](#usage-as-a-system-daemon)
+    - [Installation](#installation)
+    - [Running](#running)
+    - [Systemd Service Setup](#systemd-service-setup)
+  - [How It Works](#how-it-works)
+  - [TLS Configuration](#tls-configuration)
+  - [FAQs / Troubleshooting](#faqs--troubleshooting)
+  - [Contributing](#contributing)
+  - [Author](#author)
 
 ## Features
 
@@ -49,7 +51,7 @@ docker run -d \
   --name traefik_network_connector \
   -v $PWD/config.yaml:/usr/src/app/config.yaml \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  obeoneorg/auto_docker_proxy:latest
+  obeoneorg/traefik_network_connector:latest
 ```
 
 And it's ok !
@@ -104,7 +106,7 @@ To get started with the Traefik Network Connector, follow these steps:
 
 ### Running
 
-To use theTraefik Automatic Docker Network Connector, follow these steps:
+To use the Traefik Automatic Docker Network Connector, follow these steps:
 
 1. Ensure Docker is running and you have the necessary permissions to interact with Docker's API.
 2. Configure settings [the way you like](#configuration).

--- a/config.yaml
+++ b/config.yaml
@@ -30,6 +30,6 @@ traefik:
   containerName: "traefik"
   # Label to monitor for Traefik management (using regex)
   monitoredLabel: "^traefik.enable$"
-  # Label of auto_docker_proxy network to connect to (not mandatory on services but if present, only connect to these networks)
+  # Label of traefik_network_connector network to connect to (not mandatory on services but if present, only connect to these networks)
   # For example, if you have 2 docker networks, "autoproxy.networks" label can be "autoproxy.networks=network1" to only connect to network1
   networkLabel: "autoproxy.networks"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       - "8000:80"
 
   auto_docker_proxy:
-    image: obeoneorg/auto_docker_proxy
+    image: obeoneorg/traefik_network_connector
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 


### PR DESCRIPTION
Updated the GitHub Actions workflow to include new image tags for `traefik_network_connector`. Modified README, config.yaml, and docker-compose.yaml to replace references from `auto_docker_proxy` to `traefik_network_connector`. This change ensures consistency and clarity in naming conventions across the project.