### PR TITLE
fix(events): use Actor.ID instead of deprecated top-level id field

### DIFF
--- a/main.py
+++ b/main.py
@@ -213,19 +213,27 @@ def monitor_events():
             app_logger.warning("Traefik is not running. Skipping event handling.")
             continue
 
+        # Extract the container ID from the event.
+        # The top-level "id" field is deprecated since Docker Engine API 1.47 in favour of Actor.ID.
+        # We prefer Actor.ID and fall back to the legacy field for older engines.
+        container_id = event.get("Actor", {}).get("ID") or event.get("id")
+        if not container_id:
+            app_logger.warning("Received container event without a resolvable container ID. Skipping.")
+            continue
+
         # Update the container cache on every container event (can be manual connection to network for example)
-        update_container_cache(event["id"])
+        update_container_cache(container_id)
 
         # Check if the event is relevant for network management
         if event["Type"] in tracked_events and event["Action"] in tracked_events[event["Type"]]:
             # Fetch the container from the cache or None if not found
-            container = container_cache[event["id"]] if event["id"] in container_cache else None
+            container = container_cache[container_id] if container_id in container_cache else None
 
-            app_logger.debug(f"Event detected: {event['Action']} on container {container.name if container else event['id']} with ID {event['id']}.")
+            app_logger.debug(f"Event detected: {event['Action']} on container {container.name if container else container_id} with ID {container_id}.")
 
             # Skip further processing if the container is not found or Traefik is not running
             if container is None:
-                app_logger.warning(f"Container {event['id']} not found. Skipping event handling.")
+                app_logger.warning(f"Container {container_id} not found. Skipping event handling.")
                 continue
 
             # Define the monitored label pattern
@@ -257,7 +265,7 @@ def monitor_events():
                         f"Container {container.name} is being killed. Attempting to disconnect Traefik from relevant networks."
                     )
                     disconnect_traefik_from_network(container)
-                    del container_cache[event["id"]]
+                    del container_cache[container_id]
 
 if __name__ == "__main__":
     # Display the version


### PR DESCRIPTION
## Summary

- Replace all usages of the deprecated `event["id"]` with `event["Actor"]["ID"]` in `monitor_events()`
- Add a fallback to the legacy `id` field for backward compatibility with older Docker engines
- Add a guard clause to skip events that have no resolvable container ID

## Context

Docker Engine API 1.47 (shipped with Docker Engine 28+) deprecated the top-level `id` field on container event payloads in favour of `Actor.ID`. On Docker Engine 29.2.1+, the field is no longer present, causing a `KeyError: 'id'` crash on every container event.

See: https://docs.docker.com/engine/deprecated/#ambiguous-event-fields-in-api

## Test plan

- [ ] Run the daemon against Docker Engine ≥ 28 (where `id` is absent) and verify no `KeyError` is raised on container start/stop/die events
- [ ] Run the daemon against an older Docker Engine and verify the fallback path works correctly
- [ ] Run existing test suite: `pytest tests/`

Closes #20