### PR TITLE
add the ability to set aliases per network

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,34 +1,29 @@
 name: Claude Code Review
 
+# pull_request_target runs in the context of the BASE repo (not the fork),
+# giving access to secrets even for PRs from forks.
+# Security note: the checkout below intentionally uses the base branch ref,
+# NOT the fork's code, to avoid executing untrusted code with repo secrets.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
-      - name: Checkout repository
+      - name: Checkout base repository
         uses: actions/checkout@v4
         with:
+          # Explicitly checkout the base branch, not the fork's code.
+          # This is required when using pull_request_target with fork PRs.
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 1
 
       - name: Run Claude Code Review
@@ -41,4 +36,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/README.md
+++ b/README.md
@@ -106,6 +106,25 @@ labels:
 > A network named `frontend` in a project folder `myapp` becomes
 > `myapp_frontend`.
 
+### Network aliases
+
+If a container has the label `traefik.aliases` these aliases are set for
+traefik when it is added to the network. `traefik.aliases` must be a
+comma-separated list. Having aliases on traefik is useful to separate stacks
+but still letting a container from one stack talk through traefik to the other
+stack.
+
+```yaml
+labels:
+  - "traefik.enable=true"
+  - "traefik.aliases=myotherapp.domain"
+  - "traefik.docker.network=myapp_frontend"
+  - "traefik.http.routers.myapp.rule=Host(`myapp.${DOMAIN}`)"
+  - "traefik.http.routers.myapp.entrypoints=websecure"
+  - "traefik.http.routers.myapp.tls.certresolver=letsencrypt"
+  - "traefik.http.services.myapp.loadbalancer.server.port=8080"
+```
+
 ---
 
 ## ⚙️ Configuration

--- a/main.py
+++ b/main.py
@@ -106,6 +106,13 @@ def connect_traefik_to_network(container):
     # Retrieve allowed networks from the container's labels, if specified
     allowed_networks_label = container.labels.get(config.traefik.networkLabel, "")
     allowed_networks = allowed_networks_label.split(",")
+
+    # add alias labels
+    labels = container.attrs["Config"]["Labels"] or {}
+    alias_labels = labels.get("traefik.aliases")
+    aliases = []
+    if alias_labels:
+        aliases = [a.strip() for a in alias_labels.split(",")]
     
     app_logger.debug(f"Allowed networks: {allowed_networks}")
 
@@ -130,7 +137,10 @@ def connect_traefik_to_network(container):
         if allowed_networks == [''] or net in allowed_networks:
             if net not in traefik_container.attrs["NetworkSettings"]["Networks"]:
                 app_logger.debug(f"Connecting Traefik to network {net}.")
-                network.connect(traefik_container)
+                if aliases:
+                    network.connect(traefik_container, aliases=aliases)
+                else:
+                    network.connect(traefik_container)
                 app_logger.info(f"Successfully connected Traefik to network {net}.")
             else:
                 app_logger.info(f"Traefik is already connected to network {net}, skipping connection.")

--- a/main.py
+++ b/main.py
@@ -134,7 +134,12 @@ def connect_traefik_to_network(container):
         if allowed_networks == [''] or net in allowed_networks:
             if net not in traefik_container.attrs["NetworkSettings"]["Networks"]:
                 app_logger.debug(f"Connecting Traefik to network {net}.")
-                if aliases and net in allowed_networks:
+                # We are already inside the allowed-networks guard above, so the
+                # aliases must be applied whenever they are set, including the
+                # default case where no allowed-networks label is provided
+                # (allowed_networks == ['']). An extra net membership check here
+                # would silently drop aliases in that default case.
+                if aliases:
                     network.connect(traefik_container, aliases=aliases)
                 else:
                     network.connect(traefik_container)

--- a/main.py
+++ b/main.py
@@ -108,12 +108,9 @@ def connect_traefik_to_network(container):
     allowed_networks = allowed_networks_label.split(",")
 
     # add alias labels
-    labels = container.attrs["Config"]["Labels"] or {}
-    alias_labels = labels.get("traefik.aliases")
-    aliases = []
-    if alias_labels:
-        aliases = [a.strip() for a in alias_labels.split(",")]
-    
+    alias_label = container.labels.get("traefik.aliases")
+    aliases = [a.strip() for a in alias_label.split(",") if a.strip()] if alias_label else []
+
     app_logger.debug(f"Allowed networks: {allowed_networks}")
 
     for net in target_networks:
@@ -137,7 +134,7 @@ def connect_traefik_to_network(container):
         if allowed_networks == [''] or net in allowed_networks:
             if net not in traefik_container.attrs["NetworkSettings"]["Networks"]:
                 app_logger.debug(f"Connecting Traefik to network {net}.")
-                if aliases:
+                if aliases and net in allowed_networks:
                     network.connect(traefik_container, aliases=aliases)
                 else:
                     network.connect(traefik_container)

--- a/tests/unit/test_main_logic.py
+++ b/tests/unit/test_main_logic.py
@@ -251,6 +251,113 @@ class TestConnectTraefikToNetwork:
 
         network.connect.assert_called_once_with(traefik)
 
+    def test_no_alias_set(self, mock_docker_client, mock_config, mock_logger):
+        """
+        When traefik.aliases is not set, the container should not get an alias
+        """
+        container = MagicMock()
+        container.name = "web-app"
+        container.attrs = {
+            "NetworkSettings": {"Networks": {"app_net": {}}}
+        }
+        container.labels = {}
+
+        traefik = MagicMock()
+        traefik.attrs = {"NetworkSettings": {"Networks": {"bridge": {}}}}
+        mock_docker_client.containers.get.return_value = traefik
+
+        network = MagicMock()
+        network.attrs = {"Name": "app_net", "Labels": {}}
+        mock_docker_client.networks.get.return_value = network
+
+        main.connect_traefik_to_network(container)
+
+        network.connect.assert_called_once()
+        assert("aliases" not in network.connect.call_args.kwargs.keys())
+
+    def test_single_alias_set(self, mock_docker_client, mock_config, mock_logger):
+        """
+        When traefik.aliases is set to a single value, the network connect call
+        should have that value as alias
+        """
+        container = MagicMock()
+        container.name = "web-app"
+        container.attrs = {
+            "NetworkSettings": {"Networks": {"app_net": {}}}
+        }
+        container.labels = {
+            "traefik.aliases": "app",
+            "traefik.docker.network": "app_net",
+        }
+
+        traefik = MagicMock()
+        traefik.attrs = {"NetworkSettings": {"Networks": {"bridge": {}}}}
+        mock_docker_client.containers.get.return_value = traefik
+
+        network = MagicMock()
+        network.attrs = {"Name": "app_net", "Labels": {}}
+        mock_docker_client.networks.get.return_value = network
+
+        main.connect_traefik_to_network(container)
+
+        network.connect.assert_called_once_with(traefik, aliases=["app"])
+
+    def test_multiple_aliases_set(self, mock_docker_client, mock_config, mock_logger):
+        """
+        When traefik.aliases is set to a comma separated string, the network
+        connect call should have a list of strings value as aliases value
+        """
+        container = MagicMock()
+        container.name = "web-app"
+        container.attrs = {
+            "NetworkSettings": {"Networks": {"app_net": {}}}
+        }
+        container.labels = {
+            "traefik.aliases": "app, app2, app3",
+            "traefik.docker.network": "app_net",
+        }
+
+        traefik = MagicMock()
+        traefik.attrs = {"NetworkSettings": {"Networks": {"bridge": {}}}}
+        mock_docker_client.containers.get.return_value = traefik
+
+        network = MagicMock()
+        network.attrs = {"Name": "app_net", "Labels": {}}
+        mock_docker_client.networks.get.return_value = network
+
+        main.connect_traefik_to_network(container)
+
+        network.connect.assert_called_once_with(
+            traefik, aliases=["app", "app2", "app3"])
+
+    def test_aliases_with_additional_whitespace(self, mock_docker_client, mock_config, mock_logger):
+        """
+        When traefik.aliases is set to a comma separated string, the network
+        connect call should have a list of strings value as aliases value
+        """
+        container = MagicMock()
+        container.name = "web-app"
+        container.attrs = {
+            "NetworkSettings": {"Networks": {"app_net": {}}}
+        }
+        container.labels = {
+            "traefik.aliases": " app one, app2, app3   ",
+            "traefik.docker.network": "app_net",
+        }
+
+        traefik = MagicMock()
+        traefik.attrs = {"NetworkSettings": {"Networks": {"bridge": {}}}}
+        mock_docker_client.containers.get.return_value = traefik
+
+        network = MagicMock()
+        network.attrs = {"Name": "app_net", "Labels": {}}
+        mock_docker_client.networks.get.return_value = network
+
+        main.connect_traefik_to_network(container)
+
+        network.connect.assert_called_once_with(
+            traefik, aliases=["app one", "app2", "app3"])
+
 
 # ---------------------------------------------------------------------------
 # disconnect_traefik_from_network
@@ -462,3 +569,4 @@ class TestConnectToAllRelevantNetworks:
 
         # connect should have been called for both containers' networks
         assert network.connect.call_count == 2
+

--- a/tests/unit/test_main_logic.py
+++ b/tests/unit/test_main_logic.py
@@ -358,6 +358,33 @@ class TestConnectTraefikToNetwork:
         network.connect.assert_called_once_with(
             traefik, aliases=["app one", "app2", "app3"])
 
+    def test_alias_set_without_network_label(self, mock_docker_client, mock_config, mock_logger):
+        """
+        Regression: when traefik.aliases is set but no allowed-networks label is
+        provided (all networks allowed by default), the aliases must still be
+        applied to the network connect call.
+        """
+        container = MagicMock()
+        container.name = "web-app"
+        container.attrs = {
+            "NetworkSettings": {"Networks": {"app_net": {}}}
+        }
+        container.labels = {
+            "traefik.aliases": "app",
+        }
+
+        traefik = MagicMock()
+        traefik.attrs = {"NetworkSettings": {"Networks": {"bridge": {}}}}
+        mock_docker_client.containers.get.return_value = traefik
+
+        network = MagicMock()
+        network.attrs = {"Name": "app_net", "Labels": {}}
+        mock_docker_client.networks.get.return_value = network
+
+        main.connect_traefik_to_network(container)
+
+        network.connect.assert_called_once_with(traefik, aliases=["app"])
+
 
 # ---------------------------------------------------------------------------
 # disconnect_traefik_from_network


### PR DESCRIPTION
We have the problem that we want to isolate our backend services but they sometimes still have to talk to each other. (i.e. a webserver may need to send e-mails through a mail server)
Normally a backend container can't reach the reverse proxy by the public domain names. So with this patch we give the reverse proxy those needed public domain names as alias so one container can reach one in another stack through the reverse proxy.

an example compose file would look something like this:

~~~yaml
services:
  wordpress:
    image: wordpress
    environment:
      WORDPRESS_DB_HOST: db
      WORDPRESS_DB_USER: <user>
      WORDPRESS_DB_PASSWORD: <password>
      WORDPRESS_DB_NAME: <dbname>
    volumes:
      - wordpress:/var/www/html
    networks:
      - default
      - traefik
    labels:
      - traefik.enable=true
      - traefik.docker.network=web_traefik
      - traefik.http.routers.web.rule=Host(`domain.test`)
      - traefik.http.routers.web.entrypoints=websecure
      - traefik.http.routers.web.tls.certresolver=myresolver
      - traefik.aliases=mail.domain.test
  db:
    image: mariadb
    environment:
      MARIADB_DATABASE: <dbname>
      MARIADB_USER: <user>
      MARIADB_PASSWORD: <password>
    volumes:
      - db:/var/lib/mysql

volumes:
  wordpress:
  db:

networks:
  default:
  traefik:
~~~

`traefik.aliases` can be a comma-separated string. If there are multiple containers in a stack, `traefik.aliases` should only appear once as it may be overwritten